### PR TITLE
fix incorrect path of IPAdapterModelDir

### DIFF
--- a/configs/model/ip_adapter.py
+++ b/configs/model/ip_adapter.py
@@ -1,7 +1,7 @@
 import os
 
 IPAdapterModelDir = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "../../checkpoints", "IP-Adapter"
+    os.path.dirname(os.path.abspath(__file__)), "../../checkpoints", "IP-Adapter", "models"
 )
 
 
@@ -12,7 +12,7 @@ MotionDir = os.path.join(
 
 MODEL_CFG = {
     "IPAdapter": {
-        "ip_image_encoder": os.path.join(IPAdapterModelDir, "models/image_encoder"),
+        "ip_image_encoder": os.path.join(IPAdapterModelDir, "image_encoder"),
         "ip_ckpt": os.path.join(IPAdapterModelDir, "ip-adapter_sd15.bin"),
         "ip_scale": 1.0,
         "clip_extra_context_tokens": 4,


### PR DESCRIPTION
reference from https://huggingface.co/TMElyralab/MuseV

IP-Adapter/
`-- models
    |-- image_encoder
    |   |-- config.json
    |   |-- model.safetensors
    |   |-- models
    |   |   |-- buffalo_l
    |   |   |   |-- 1k3d68.onnx
    |   |   |   |-- 2d106det.onnx
    |   |   |   |-- det_10g.onnx
    |   |   |   |-- genderage.onnx
    |   |   |   `-- w600k_r50.onnx
    |   |   `-- buffalo_l.zip
    |   `-- pytorch_model.bin
    |-- ip-adapter-faceid_sd15.bin
    |-- ip-adapter-plus-face_sd15.bin
    |-- ip-adapter-plus_sd15.bin
    `-- ip-adapter_sd15.bin